### PR TITLE
WKS-2321 - Add triggeringUserName to PlatformContext API

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -173,6 +173,11 @@ export interface PlatformContext {
      */
     platformToken: string;
     /**
+     * Username of the principal that triggered this execution (for example via HTTP manual execute).
+     * Empty when not available.
+     */
+    triggeringUserName: string;
+    /**
      * State manager to store and retrieve state for this Worker between executions.
      * NOTE: This state is not safe against concurrent executions of the same Worker.
      * NOTE: The state will not be saved in case of execution failure.


### PR DESCRIPTION
## Summary

Adds **`triggeringUserName`** to `PlatformContext` in `api/index.ts` — the username of the principal that triggered the worker execution (for example HTTP manual execute).

## Test plan

- [ ] Regenerate/publish `jfrog-workers` types from this API when applicable.
- [ ] Confirm worker runtime exposes `context.triggeringUserName` on platforms with WKS-2321+.