### PR TITLE
WKS-2577 - Rollback triggeringUserName from PlatformContext

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -173,11 +173,6 @@ export interface PlatformContext {
      */
     platformToken: string;
     /**
-     * Username of the principal that triggered this execution (for example via HTTP manual execute).
-     * Empty when not available.
-     */
-    triggeringUserName: string;
-    /**
      * State manager to store and retrieve state for this Worker between executions.
      * NOTE: This state is not safe against concurrent executions of the same Worker.
      * NOTE: The state will not be saved in case of execution failure.


### PR DESCRIPTION
## Summary
- Removes `triggeringUserName` from `PlatformContext` in `api/index.ts` (reverts WKS-2321 / `a595f19`).
- Pairs with platform-extension rollback WKS-2577 / #2009, which pins `jfrog-workers` to `0.13.0` until this package is republished.

## Release
On merge to `main`, the **Publish Workers API** workflow bumps the minor version and publishes to npm (expected **0.15.0** without `triggeringUserName`).

After publish, update platform-extension `jfrog-workers` from `0.13.0` → `0.15.0` in frontend and service.

## Test plan
- [ ] `cd api && npm run build`
- [ ] Merge and confirm npm publish succeeds
- [ ] Worker TypeScript compile in platform-extension with new package version


Made with [Cursor](https://cursor.com)